### PR TITLE
Add word cloud visualization feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ HAAM implements the Human-AI Accuracy Model framework for understanding how huma
 - 📊 **Sample-split post-lasso regression** for unbiased statistical inference
 - 🔍 **Automatic topic modeling** to interpret principal components using c-TF-IDF
 - 📈 **Interactive visualizations** including framework diagrams, coefficient grids, and 3D UMAP plots
+- ☁️ **Word cloud visualizations** for PC poles with customizable color schemes (red for high, blue for low)
 - 💾 **Comprehensive metrics export** including top/bottom topics for all 200 PCs
 - 🔄 **R compatibility** via reticulate
 

--- a/docs/wordcloud_feature.md
+++ b/docs/wordcloud_feature.md
@@ -1,0 +1,175 @@
+# Word Cloud Feature for HAAM
+
+## Overview
+
+The word cloud feature in HAAM generates visual representations of the topics associated with the high and low poles of each principal component (PC). This helps researchers quickly understand what each PC represents by visualizing the most relevant keywords.
+
+## Features
+
+- **Bipolar Visualization**: Each PC gets two word clouds - one for high pole topics (red) and one for low pole topics (blue)
+- **Customizable Parameters**: Control the number of topics (k), maximum words, and figure sizes
+- **Batch Generation**: Generate word clouds for multiple PCs at once
+- **Grid Visualization**: Create compact grid views showing multiple PCs
+
+## Installation
+
+The word cloud feature requires the `wordcloud` package:
+
+```bash
+pip install wordcloud
+```
+
+This is automatically included when installing HAAM:
+
+```bash
+pip install git+https://github.com/raymondli-me/haam.git
+```
+
+## Usage
+
+### Basic Usage - Single PC
+
+```python
+from haam import HAAM
+
+# After running HAAM analysis
+haam = HAAM(criterion, ai_judgment, human_judgment, texts=texts)
+
+# Generate word clouds for PC1 (index 0)
+fig, high_path, low_path = haam.create_pc_wordclouds(
+    pc_idx=0,  # PC1
+    k=10,  # Use top/bottom 10 topics
+    max_words=100,  # Show up to 100 words
+    output_dir='./wordclouds',
+    display=True
+)
+```
+
+### Batch Generation
+
+```python
+# Generate word clouds for specific PCs
+pc_indices = [0, 3, 7, 12]  # PC1, PC4, PC8, PC13
+
+output_paths = haam.create_all_pc_wordclouds(
+    pc_indices=pc_indices,
+    k=15,  # More topics for richer clouds
+    max_words=150,
+    output_dir='./wordclouds/batch',
+    display=False
+)
+
+# Or auto-select top PCs
+output_paths = haam.create_all_pc_wordclouds(
+    pc_indices=None,  # Auto-selects top 9 by 'triple' ranking
+    k=10,
+    output_dir='./wordclouds/top_pcs'
+)
+```
+
+### Grid Visualization
+
+```python
+# Create a grid showing multiple PCs at once
+fig = haam.create_top_pcs_wordcloud_grid(
+    pc_indices=None,  # Auto-select top PCs
+    ranking_method='triple',  # or 'HU', 'AI', 'Y'
+    n_pcs=9,  # Show 9 PCs in 3x3 grid
+    k=10,
+    max_words=50,
+    output_file='./wordcloud_grid.png',
+    display=True
+)
+```
+
+## Parameters
+
+### `create_pc_wordclouds()`
+
+- **pc_idx** (int): PC index (0-based)
+- **k** (int, default=10): Number of topics to include from each pole
+- **max_words** (int, default=100): Maximum words to display in word cloud
+- **figsize** (tuple, default=(10, 5)): Figure size (width, height) for each subplot
+- **output_dir** (str, optional): Directory to save output files
+- **display** (bool, default=True): Whether to display the plots
+
+### `create_all_pc_wordclouds()`
+
+- **pc_indices** (list, optional): List of PC indices. If None, uses top 9 PCs by 'triple' ranking
+- **k** (int, default=10): Number of topics to include from each pole
+- **max_words** (int, default=100): Maximum words to display
+- **figsize** (tuple, default=(10, 5)): Figure size for each subplot
+- **output_dir** (str, default='./wordclouds'): Directory to save output files
+- **display** (bool, default=False): Whether to display each plot
+
+### `create_top_pcs_wordcloud_grid()`
+
+- **pc_indices** (list, optional): List of PC indices. If None, uses top PCs by ranking_method
+- **ranking_method** (str, default='triple'): Method to rank PCs ('triple', 'HU', 'AI', 'Y')
+- **n_pcs** (int, default=9): Number of top PCs to include if pc_indices not provided
+- **k** (int, default=10): Number of topics to include from each pole
+- **max_words** (int, default=50): Maximum words per word cloud
+- **output_file** (str, optional): Path to save the grid visualization
+- **display** (bool, default=True): Whether to display the plot
+
+## Color Schemes
+
+- **High Pole**: Red gradient (light red to dark red)
+- **Low Pole**: Blue gradient (light blue to dark blue)
+
+The color intensity represents word frequency within the aggregated topics.
+
+## Output Files
+
+The feature generates several types of output files:
+
+1. **Combined Word Clouds**: `pc{N}_wordclouds.png` - Shows both high and low poles side by side
+2. **Individual High Pole**: `pc{N}_high_wordcloud.png` - Just the high pole word cloud
+3. **Individual Low Pole**: `pc{N}_low_wordcloud.png` - Just the low pole word cloud
+4. **Grid Visualization**: `pc_wordcloud_grid.png` - Multiple PCs in one figure
+
+## Technical Details
+
+### Topic Aggregation
+
+The word cloud generator aggregates keywords from multiple topics:
+1. Retrieves k topics with highest/lowest average PC values
+2. Weights keywords by topic rank (higher ranked topics contribute more)
+3. Aggregates all keywords with frequency weighting
+4. Generates word cloud from aggregated text
+
+### Statistical Filtering
+
+Only statistically significant topics (p < 0.05) are included in the word clouds.
+
+## Examples
+
+See `examples/wordcloud_example.py` for comprehensive examples including:
+- Single PC visualization
+- Batch processing
+- Grid layouts
+- Integration with full HAAM workflow
+- Custom parameter configurations
+
+## Troubleshooting
+
+### No Word Clouds Generated
+
+If you see "No significant high/low topics", this means:
+- The PC has no topics with statistically significant associations (p > 0.05)
+- Try increasing k to include more topics
+- Check if topic analysis was performed (requires texts during initialization)
+
+### Import Error
+
+If you get `ImportError: wordcloud package not installed`:
+```bash
+pip install wordcloud
+```
+
+### Memory Issues
+
+For large datasets or many PCs:
+- Process PCs in smaller batches
+- Reduce max_words parameter
+- Set display=False to avoid showing plots

--- a/examples/wordcloud_example.py
+++ b/examples/wordcloud_example.py
@@ -1,0 +1,216 @@
+"""
+Example: PC Word Cloud Visualizations
+====================================
+
+This example demonstrates how to create word cloud visualizations
+for principal component poles (high vs low) in HAAM.
+"""
+
+import numpy as np
+from haam import HAAM
+
+# Example 1: Create word clouds for a single PC
+def example_single_pc_wordcloud():
+    """Create word clouds for high and low poles of a specific PC."""
+    print("Example 1: Word clouds for a single PC")
+    print("-" * 50)
+    
+    # Load your data (replace with actual data)
+    n_samples = 1000
+    data = {
+        'criterion': np.random.randn(n_samples),
+        'ai_judgment': np.random.randn(n_samples),
+        'human_judgment': np.random.randn(n_samples),
+        'text': [f"Sample text {i} with various topics and content." for i in range(n_samples)]
+    }
+    
+    # Initialize and run HAAM
+    haam = HAAM(
+        criterion=data['criterion'],
+        ai_judgment=data['ai_judgment'],
+        human_judgment=data['human_judgment'],
+        texts=data['text'],
+        n_components=200
+    )
+    
+    # Create word clouds for PC1 (index 0)
+    fig, high_path, low_path = haam.create_pc_wordclouds(
+        pc_idx=0,  # PC1
+        k=10,  # Use top/bottom 10 topics
+        max_words=100,  # Show up to 100 words
+        figsize=(10, 5),  # Size of each word cloud
+        output_dir='./wordcloud_outputs',
+        display=True
+    )
+    
+    print(f"High pole word cloud saved to: {high_path}")
+    print(f"Low pole word cloud saved to: {low_path}")
+
+
+# Example 2: Create word clouds for multiple specific PCs
+def example_multiple_pcs_wordclouds():
+    """Create word clouds for selected PCs of interest."""
+    print("\nExample 2: Word clouds for multiple PCs")
+    print("-" * 50)
+    
+    # Assume haam is already initialized
+    # Select specific PCs of interest
+    pc_indices = [0, 3, 7]  # PC1, PC4, PC8
+    
+    output_paths = haam.create_all_pc_wordclouds(
+        pc_indices=pc_indices,
+        k=15,  # Use more topics for richer word clouds
+        max_words=150,
+        figsize=(12, 6),
+        output_dir='./wordcloud_outputs/selected_pcs',
+        display=False  # Don't display each one individually
+    )
+    
+    print(f"Created word clouds for {len(output_paths)} PCs")
+    for pc_idx, (high_path, low_path) in output_paths.items():
+        print(f"  PC{pc_idx + 1}: {high_path}, {low_path}")
+
+
+# Example 3: Auto-generate word clouds for top PCs
+def example_top_pcs_wordclouds():
+    """Automatically create word clouds for the most important PCs."""
+    print("\nExample 3: Word clouds for top PCs")
+    print("-" * 50)
+    
+    # Create word clouds for top 9 PCs (auto-selected by 'triple' ranking)
+    output_paths = haam.create_all_pc_wordclouds(
+        pc_indices=None,  # Will auto-select top 9 by 'triple' ranking
+        k=10,
+        max_words=100,
+        output_dir='./wordcloud_outputs/top_pcs',
+        display=False
+    )
+    
+    print(f"Created word clouds for top {len(output_paths)} PCs")
+
+
+# Example 4: Create a grid visualization
+def example_wordcloud_grid():
+    """Create a grid showing all top PC word clouds in one figure."""
+    print("\nExample 4: Word cloud grid for top PCs")
+    print("-" * 50)
+    
+    # Create grid visualization
+    fig = haam.create_top_pcs_wordcloud_grid(
+        pc_indices=None,  # Auto-select top PCs
+        ranking_method='triple',  # Use triple selection method
+        n_pcs=9,  # Show top 9 PCs
+        k=10,  # Topics per pole
+        max_words=50,  # Fewer words for grid view
+        output_file='./wordcloud_outputs/pc_wordcloud_grid.png',
+        display=True
+    )
+    
+    print("Grid visualization created and saved")
+
+
+# Example 5: Customize parameters for different analyses
+def example_custom_parameters():
+    """Demonstrate different parameter settings for various use cases."""
+    print("\nExample 5: Custom parameter examples")
+    print("-" * 50)
+    
+    # Use case 1: Detailed analysis with many topics
+    print("\nDetailed analysis with k=20 topics:")
+    haam.create_pc_wordclouds(
+        pc_idx=0,
+        k=20,  # Include top/bottom 20 topics
+        max_words=200,  # Show more words
+        figsize=(14, 7),  # Larger figure
+        output_dir='./wordcloud_outputs/detailed',
+        display=False
+    )
+    
+    # Use case 2: Quick overview with fewer topics
+    print("\nQuick overview with k=5 topics:")
+    haam.create_pc_wordclouds(
+        pc_idx=0,
+        k=5,  # Only top/bottom 5 topics
+        max_words=50,  # Fewer words for clarity
+        figsize=(8, 4),  # Smaller figure
+        output_dir='./wordcloud_outputs/overview',
+        display=False
+    )
+    
+    # Use case 3: Focus on human-selected PCs
+    print("\nHuman-judgment focused PCs:")
+    human_top_pcs = haam.analysis.get_top_pcs(n=6, ranking_method='HU')
+    output_paths = haam.create_all_pc_wordclouds(
+        pc_indices=human_top_pcs,
+        k=12,
+        output_dir='./wordcloud_outputs/human_pcs',
+        display=False
+    )
+    print(f"Created word clouds for {len(output_paths)} human-focused PCs")
+
+
+# Example 6: Integration with full HAAM workflow
+def example_full_workflow():
+    """Complete workflow from data to word cloud visualizations."""
+    print("\nExample 6: Full HAAM workflow with word clouds")
+    print("-" * 50)
+    
+    # Load real data
+    import pandas as pd
+    df = pd.read_csv('your_data.csv')  # Replace with your file
+    
+    # Run HAAM analysis
+    haam = HAAM(
+        criterion=df['target_variable'],
+        ai_judgment=df['ai_scores'],
+        human_judgment=df['human_scores'],
+        texts=df['text_content'].tolist(),
+        n_components=200
+    )
+    
+    # Export standard results
+    haam.export_all_results('./haam_output')
+    
+    # Add word cloud visualizations
+    # 1. Grid overview
+    haam.create_top_pcs_wordcloud_grid(
+        output_file='./haam_output/visualizations/wordcloud_grid.png'
+    )
+    
+    # 2. Individual word clouds for all top PCs
+    output_paths = haam.create_all_pc_wordclouds(
+        output_dir='./haam_output/wordclouds',
+        k=15,
+        max_words=150
+    )
+    
+    print(f"Full analysis complete with {len(output_paths)} PC word clouds")
+    
+    # 3. Explore specific interesting PCs
+    # First check what each PC represents
+    pc_topics = haam.explore_pc_topics(pc_indices=list(range(10)))
+    print("\nPC meanings from topic analysis:")
+    for i in range(10):
+        pc_data = pc_topics[pc_topics['PC'] == i+1]
+        if not pc_data.empty:
+            print(f"PC{i+1}: {pc_data.iloc[0]['Direction']} - {pc_data.iloc[0]['Keywords'][:50]}...")
+
+
+if __name__ == "__main__":
+    # Note: You'll need to initialize a global 'haam' object or modify
+    # these examples to work with your specific data setup
+    
+    try:
+        # Run basic example
+        example_single_pc_wordcloud()
+        
+        # Uncomment to run other examples after initializing haam:
+        # example_multiple_pcs_wordclouds()
+        # example_top_pcs_wordclouds()
+        # example_wordcloud_grid()
+        # example_custom_parameters()
+        # example_full_workflow()
+        
+    except Exception as e:
+        print(f"Example failed: {e}")
+        print("Make sure to provide real data or adjust the examples for your use case.")

--- a/generate_wordclouds_nvembed.py
+++ b/generate_wordclouds_nvembed.py
@@ -1,0 +1,285 @@
+#!/usr/bin/env python3
+
+"""
+Word Cloud Generation Script for HAAM Analysis Results
+======================================================
+This script loads the existing HAAM analysis results and generates
+word cloud visualizations for specific principal components.
+"""
+
+# Install wordcloud if not already installed
+!pip install wordcloud
+
+# Mount Google Drive (if not already mounted)
+from google.colab import drive
+import os
+if not os.path.exists('/content/drive'):
+    drive.mount('/content/drive')
+
+import pandas as pd
+import numpy as np
+import pickle
+import matplotlib.pyplot as plt
+from haam import HAAM
+import warnings
+warnings.filterwarnings('ignore')
+
+print("="*80)
+print("WORD CLOUD GENERATION FOR HAAM ANALYSIS")
+print("="*80)
+
+# ==============================================================================
+# LOAD EXISTING HAAM ANALYSIS
+# ==============================================================================
+
+print("\n1. LOADING EXISTING HAAM ANALYSIS...")
+print("-"*60)
+
+# Load the same data as in your initial analysis
+filename = 'combined_social_class_dataset_v2.csv'
+data_path = f'/content/drive/MyDrive/2025_06_30_anonymized_data_dmllme_2025_06_30/NV_Embed_Combined/{filename}'
+
+if not os.path.exists(data_path):
+    raise FileNotFoundError(f"Data file not found: {data_path}")
+
+df = pd.read_csv(data_path)
+print(f"✓ Loaded: {df.shape[0]} rows, {df.shape[1]} columns")
+
+# Extract data with same column names as initial analysis
+texts = df['text'].values.tolist()
+embedding_cols = [f'embed_dim_{i}' for i in range(4096)]
+embeddings = df[embedding_cols].values
+social_class = df['social_class'].astype(float).values
+ai_rating = df['ai_rating'].astype(float).values
+human_rating = df['SC_RATING_11'].astype(float).values
+
+print(f"\nData summary:")
+print(f"  Total essays: {len(texts)}")
+print(f"  Valid human ratings: {(~np.isnan(human_rating)).sum()} ({(~np.isnan(human_rating)).sum()/len(human_rating)*100:.1f}%)")
+
+# ==============================================================================
+# RE-INITIALIZE HAAM WITH SAME PARAMETERS
+# ==============================================================================
+
+print("\n2. RE-INITIALIZING HAAM...")
+print("-"*60)
+print("Note: This will reload the analysis to access the topic analyzer")
+
+# Initialize HAAM with exact same parameters as your initial run
+haam = HAAM(
+    criterion=social_class,
+    ai_judgment=ai_rating,
+    human_judgment=human_rating,
+    embeddings=embeddings,
+    texts=texts,
+    n_components=200,
+    min_cluster_size=10,
+    min_samples=2,
+    umap_n_components=3,
+    standardize=True,
+    sample_split_post_lasso=False,
+    auto_run=True
+)
+
+print("✓ HAAM analysis reloaded successfully!")
+print(f"✓ Topic analyzer available: {hasattr(haam, 'topic_analyzer') and haam.topic_analyzer is not None}")
+
+# ==============================================================================
+# GENERATE WORD CLOUDS FOR SPECIFIC PCs
+# ==============================================================================
+
+print("\n3. GENERATING WORD CLOUDS FOR SPECIFIC PCs...")
+print("-"*60)
+
+# Define the specific PCs you want (0-based indices)
+# You specified: PC3,2,4,5,6,15,14,12,13,47,10,18,17,21,106
+specific_pcs = [2, 1, 3, 4, 5, 14, 13, 11, 12, 46, 9, 17, 16, 20, 105]  # 0-based indices
+
+print(f"Generating word clouds for {len(specific_pcs)} specific PCs:")
+print(f"PC indices (1-based): {[pc+1 for pc in specific_pcs]}")
+
+# Create output directory for word clouds
+wordcloud_dir = 'haam_wordclouds_specific'
+os.makedirs(wordcloud_dir, exist_ok=True)
+
+# Parameters for word cloud generation
+k_topics = 15  # Number of topics to include from each pole
+max_words = 150  # Maximum words in each word cloud
+figsize = (12, 6)  # Size of each word cloud figure
+
+# Generate word clouds for each specific PC
+print("\nGenerating individual word clouds...")
+successful_pcs = []
+failed_pcs = []
+
+for i, pc_idx in enumerate(specific_pcs):
+    print(f"\n  [{i+1}/{len(specific_pcs)}] Creating word cloud for PC{pc_idx + 1}...")
+    
+    try:
+        fig, high_path, low_path = haam.create_pc_wordclouds(
+            pc_idx=pc_idx,
+            k=k_topics,
+            max_words=max_words,
+            figsize=figsize,
+            output_dir=wordcloud_dir,
+            display=False  # Don't display each one individually
+        )
+        plt.close(fig)  # Close figure to save memory
+        
+        print(f"    ✓ High pole: {high_path}")
+        print(f"    ✓ Low pole: {low_path}")
+        successful_pcs.append(pc_idx)
+        
+    except Exception as e:
+        print(f"    ✗ Failed: {str(e)}")
+        failed_pcs.append(pc_idx)
+
+print(f"\n✓ Successfully generated word clouds for {len(successful_pcs)} PCs")
+if failed_pcs:
+    print(f"✗ Failed for {len(failed_pcs)} PCs: {[pc+1 for pc in failed_pcs]}")
+
+# ==============================================================================
+# CREATE GRID VISUALIZATION
+# ==============================================================================
+
+print("\n4. CREATING GRID VISUALIZATION...")
+print("-"*60)
+
+# Create a grid showing the first 9 of your specific PCs
+grid_pcs = specific_pcs[:9]  # Take first 9 for a 3x3 grid
+print(f"Creating grid visualization for PCs: {[pc+1 for pc in grid_pcs]}")
+
+try:
+    grid_fig = haam.create_top_pcs_wordcloud_grid(
+        pc_indices=grid_pcs,
+        k=10,  # Fewer topics for grid view
+        max_words=50,  # Fewer words for clarity in grid
+        output_file=os.path.join(wordcloud_dir, 'pc_wordcloud_grid_specific.png'),
+        display=True
+    )
+    print("✓ Grid visualization saved successfully!")
+except Exception as e:
+    print(f"✗ Grid visualization failed: {str(e)}")
+
+# ==============================================================================
+# BATCH GENERATION FOR ALL SPECIFIC PCs
+# ==============================================================================
+
+print("\n5. BATCH GENERATING ALL WORD CLOUDS...")
+print("-"*60)
+
+# Generate all word clouds in batch mode
+print(f"Generating word clouds for all {len(specific_pcs)} specified PCs...")
+
+try:
+    output_paths = haam.create_all_pc_wordclouds(
+        pc_indices=specific_pcs,
+        k=k_topics,
+        max_words=max_words,
+        figsize=figsize,
+        output_dir=os.path.join(wordcloud_dir, 'batch'),
+        display=False
+    )
+    
+    print(f"\n✓ Batch generation complete!")
+    print(f"✓ Generated word clouds for {len(output_paths)} PCs")
+    
+except Exception as e:
+    print(f"✗ Batch generation failed: {str(e)}")
+
+# ==============================================================================
+# EXPLORE PC TOPICS FOR CONTEXT
+# ==============================================================================
+
+print("\n6. EXPLORING PC TOPICS FOR CONTEXT...")
+print("-"*60)
+
+# Get topic information for the specific PCs
+print("Retrieving topic information for each PC...")
+
+try:
+    pc_topics_df = haam.explore_pc_topics(pc_indices=specific_pcs, n_topics=5)
+    
+    # Save topic exploration results
+    topics_path = os.path.join(wordcloud_dir, 'pc_topics_exploration.csv')
+    pc_topics_df.to_csv(topics_path, index=False)
+    print(f"✓ Saved topic exploration: {topics_path}")
+    
+    # Display summary for each PC
+    print("\nPC Topic Summary:")
+    print("-"*60)
+    for pc_idx in specific_pcs:
+        pc_data = pc_topics_df[pc_topics_df['PC'] == pc_idx + 1]
+        if not pc_data.empty:
+            print(f"\nPC{pc_idx + 1}:")
+            high_data = pc_data[pc_data['Direction'] == 'HIGH']
+            low_data = pc_data[pc_data['Direction'] == 'LOW']
+            
+            if not high_data.empty:
+                print(f"  HIGH: {high_data.iloc[0]['Keywords'][:80]}...")
+            if not low_data.empty:
+                print(f"  LOW:  {low_data.iloc[0]['Keywords'][:80]}...")
+                
+except Exception as e:
+    print(f"✗ Topic exploration failed: {str(e)}")
+
+# ==============================================================================
+# CREATE CUSTOM VISUALIZATIONS
+# ==============================================================================
+
+print("\n7. CREATING CUSTOM VISUALIZATIONS...")
+print("-"*60)
+
+# Create a custom figure showing word clouds for the most important PCs
+# Based on different ranking methods
+
+ranking_methods = ['HU', 'AI', 'Y']
+
+for ranking in ranking_methods:
+    print(f"\nCreating word cloud grid for top PCs by {ranking} ranking...")
+    
+    try:
+        # Get top PCs by this ranking
+        top_pcs_by_ranking = haam.analysis.get_top_pcs(n=9, ranking_method=ranking)
+        
+        # Create grid for these PCs
+        grid_path = os.path.join(wordcloud_dir, f'wordcloud_grid_{ranking.lower()}_ranking.png')
+        fig = haam.create_top_pcs_wordcloud_grid(
+            pc_indices=top_pcs_by_ranking,
+            k=10,
+            max_words=50,
+            output_file=grid_path,
+            display=False
+        )
+        print(f"  ✓ Saved: {grid_path}")
+        
+    except Exception as e:
+        print(f"  ✗ Failed: {str(e)}")
+
+# ==============================================================================
+# FINAL SUMMARY
+# ==============================================================================
+
+print("\n" + "="*80)
+print("WORD CLOUD GENERATION COMPLETE!")
+print("="*80)
+
+print(f"\nAll word clouds saved to: {wordcloud_dir}/")
+print("\nGenerated files:")
+print(f"  📊 Individual word clouds for {len(successful_pcs)} PCs")
+print(f"  🎨 Grid visualization: pc_wordcloud_grid_specific.png")
+print(f"  📁 Batch word clouds in: {wordcloud_dir}/batch/")
+print(f"  📝 Topic exploration: pc_topics_exploration.csv")
+print(f"  🎯 Ranking-based grids for HU, AI, and Y")
+
+print("\nSpecific PCs processed (1-based):")
+print(f"  {[pc+1 for pc in specific_pcs]}")
+
+print("\nWord cloud parameters used:")
+print(f"  - Topics per pole (k): {k_topics}")
+print(f"  - Max words displayed: {max_words}")
+print(f"  - Figure size: {figsize}")
+
+print("\n✅ Word cloud generation complete!")
+print("🎨 Red gradients = High pole topics")
+print("🎨 Blue gradients = Low pole topics")

--- a/haam/__init__.py
+++ b/haam/__init__.py
@@ -4,7 +4,8 @@ from .haam_init import HAAM
 from .haam_package import HAAMAnalysis
 from .haam_topics import TopicAnalyzer
 from .haam_visualizations import HAAMVisualizer
+from .haam_wordcloud import PCWordCloudGenerator
 from .haam_bws import HAAMwithBWS
 
 __version__ = "1.2.0"
-__all__ = ["HAAM", "HAAMwithBWS", "HAAMAnalysis", "TopicAnalyzer", "HAAMVisualizer"]
+__all__ = ["HAAM", "HAAMwithBWS", "HAAMAnalysis", "TopicAnalyzer", "HAAMVisualizer", "PCWordCloudGenerator"]

--- a/haam/haam_init.py
+++ b/haam/haam_init.py
@@ -8,6 +8,7 @@ Main module providing a simplified interface for HAAM analysis.
 from .haam_package import HAAMAnalysis
 from .haam_topics import TopicAnalyzer
 from .haam_visualizations import HAAMVisualizer
+from .haam_wordcloud import PCWordCloudGenerator
 import numpy as np
 import pandas as pd
 import umap
@@ -717,6 +718,151 @@ class HAAM:
         )
         
         return output_file
+    
+    def create_pc_wordclouds(self,
+                           pc_idx: int,
+                           k: int = 10,
+                           max_words: int = 100,
+                           figsize: Tuple[int, int] = (10, 5),
+                           output_dir: Optional[str] = None,
+                           display: bool = True) -> Tuple[Any, str, str]:
+        """
+        Create word clouds for high and low poles of a specific PC.
+        
+        Parameters
+        ----------
+        pc_idx : int
+            PC index (0-based)
+        k : int
+            Number of topics to include from each pole
+        max_words : int
+            Maximum words to display in word cloud
+        figsize : Tuple[int, int]
+            Figure size (width, height) for each subplot
+        output_dir : str, optional
+            Directory to save output files
+        display : bool
+            Whether to display the plots
+            
+        Returns
+        -------
+        Tuple[Figure, str, str]
+            Figure object, high pole output path, low pole output path
+        """
+        if not hasattr(self, 'topic_analyzer') or self.topic_analyzer is None:
+            raise ValueError("Topic analysis not performed. Initialize with texts to enable topic analysis.")
+            
+        if not hasattr(self, 'wordcloud_generator'):
+            self.wordcloud_generator = PCWordCloudGenerator(self.topic_analyzer)
+            
+        return self.wordcloud_generator.create_pc_wordclouds(
+            pc_idx=pc_idx,
+            k=k,
+            max_words=max_words,
+            figsize=figsize,
+            output_dir=output_dir,
+            display=display
+        )
+    
+    def create_all_pc_wordclouds(self,
+                               pc_indices: Optional[List[int]] = None,
+                               k: int = 10,
+                               max_words: int = 100,
+                               figsize: Tuple[int, int] = (10, 5),
+                               output_dir: str = './wordclouds',
+                               display: bool = False) -> Dict[int, Tuple[str, str]]:
+        """
+        Create word clouds for all specified PCs.
+        
+        Parameters
+        ----------
+        pc_indices : List[int], optional
+            List of PC indices. If None, uses top 9 PCs by 'triple' ranking
+        k : int
+            Number of topics to include from each pole
+        max_words : int
+            Maximum words to display in word cloud
+        figsize : Tuple[int, int]
+            Figure size for each subplot
+        output_dir : str
+            Directory to save output files
+        display : bool
+            Whether to display each plot
+            
+        Returns
+        -------
+        Dict[int, Tuple[str, str]]
+            Dictionary mapping PC index to (high_path, low_path)
+        """
+        if not hasattr(self, 'topic_analyzer') or self.topic_analyzer is None:
+            raise ValueError("Topic analysis not performed. Initialize with texts to enable topic analysis.")
+            
+        if not hasattr(self, 'wordcloud_generator'):
+            self.wordcloud_generator = PCWordCloudGenerator(self.topic_analyzer)
+            
+        # If no indices specified, use top 9 PCs
+        if pc_indices is None:
+            pc_indices = self.analysis.get_top_pcs(n=9, ranking_method='triple')
+            
+        return self.wordcloud_generator.create_all_pc_wordclouds(
+            pc_indices=pc_indices,
+            k=k,
+            max_words=max_words,
+            figsize=figsize,
+            output_dir=output_dir,
+            display=display
+        )
+    
+    def create_top_pcs_wordcloud_grid(self,
+                                    pc_indices: Optional[List[int]] = None,
+                                    ranking_method: str = 'triple',
+                                    n_pcs: int = 9,
+                                    k: int = 10,
+                                    max_words: int = 50,
+                                    output_file: Optional[str] = None,
+                                    display: bool = True) -> Any:
+        """
+        Create a grid visualization of word clouds for top PCs.
+        
+        Parameters
+        ----------
+        pc_indices : List[int], optional
+            List of PC indices. If None, uses top PCs by ranking_method
+        ranking_method : str
+            Method to rank PCs if pc_indices not provided: 'triple', 'HU', 'AI', 'SC'
+        n_pcs : int
+            Number of top PCs to include if pc_indices not provided
+        k : int
+            Number of topics to include from each pole
+        max_words : int
+            Maximum words per word cloud
+        output_file : str, optional
+            Path to save the grid visualization
+        display : bool
+            Whether to display the plot
+            
+        Returns
+        -------
+        Figure
+            Figure object
+        """
+        if not hasattr(self, 'topic_analyzer') or self.topic_analyzer is None:
+            raise ValueError("Topic analysis not performed. Initialize with texts to enable topic analysis.")
+            
+        if not hasattr(self, 'wordcloud_generator'):
+            self.wordcloud_generator = PCWordCloudGenerator(self.topic_analyzer)
+            
+        # If no indices specified, use top PCs
+        if pc_indices is None:
+            pc_indices = self.analysis.get_top_pcs(n=n_pcs, ranking_method=ranking_method)
+            
+        return self.wordcloud_generator.create_top_pcs_wordcloud_grid(
+            pc_indices=pc_indices,
+            k=k,
+            max_words=max_words,
+            output_file=output_file,
+            display=display
+        )
     
     def export_all_results(self, output_dir: Optional[str] = None) -> Dict[str, str]:
         """

--- a/haam/haam_wordcloud.py
+++ b/haam/haam_wordcloud.py
@@ -1,0 +1,381 @@
+"""
+HAAM Word Cloud Module
+=====================
+
+Generate word clouds for PC poles (high and low) with customized coloring.
+"""
+
+import numpy as np
+import matplotlib.pyplot as plt
+from matplotlib.colors import LinearSegmentedColormap
+from typing import Dict, List, Optional, Tuple, Union
+import os
+from collections import Counter
+import warnings
+warnings.filterwarnings('ignore')
+
+
+class PCWordCloudGenerator:
+    """
+    Generate word clouds for principal component poles.
+    """
+    
+    def __init__(self, topic_analyzer):
+        """
+        Initialize word cloud generator.
+        
+        Parameters
+        ----------
+        topic_analyzer : TopicAnalyzer
+            TopicAnalyzer instance with computed topics and PC associations
+        """
+        self.topic_analyzer = topic_analyzer
+        
+    def create_pc_wordclouds(self, 
+                           pc_idx: int,
+                           k: int = 10,
+                           max_words: int = 100,
+                           figsize: Tuple[int, int] = (10, 5),
+                           output_dir: Optional[str] = None,
+                           display: bool = True) -> Tuple[plt.Figure, str, str]:
+        """
+        Create word clouds for high and low poles of a specific PC.
+        
+        Parameters
+        ----------
+        pc_idx : int
+            PC index (0-based)
+        k : int
+            Number of topics to include from each pole
+        max_words : int
+            Maximum words to display in word cloud
+        figsize : Tuple[int, int]
+            Figure size (width, height) for each subplot
+        output_dir : str, optional
+            Directory to save output files
+        display : bool
+            Whether to display the plots
+            
+        Returns
+        -------
+        Tuple[plt.Figure, str, str]
+            Figure object, high pole output path, low pole output path
+        """
+        try:
+            from wordcloud import WordCloud
+        except ImportError:
+            raise ImportError("wordcloud package not installed. Install with: pip install wordcloud")
+            
+        # Get high and low topics for this PC
+        pc_topics = self.topic_analyzer.get_pc_high_low_topics(
+            pc_idx=pc_idx,
+            n_high=k,
+            n_low=k,
+            p_threshold=0.05
+        )
+        
+        # Create figure with two subplots
+        fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(figsize[0]*2, figsize[1]))
+        
+        # Process high pole topics
+        high_text = self._aggregate_topic_keywords(pc_topics['high'])
+        if high_text:
+            # Create red colormap for high pole
+            colors_red = ["#ffcccc", "#ff9999", "#ff6666", "#ff3333", "#cc0000", "#990000"]
+            cmap_red = LinearSegmentedColormap.from_list("red_gradient", colors_red)
+            
+            wc_high = WordCloud(
+                width=800,
+                height=400,
+                background_color='white',
+                colormap=cmap_red,
+                max_words=max_words,
+                relative_scaling=0.5,
+                min_font_size=10
+            ).generate(high_text)
+            
+            ax1.imshow(wc_high, interpolation='bilinear')
+            ax1.set_title(f'PC{pc_idx + 1} - High Pole Topics', fontsize=16, fontweight='bold', color='darkred')
+            ax1.axis('off')
+        else:
+            ax1.text(0.5, 0.5, 'No significant high topics', 
+                    horizontalalignment='center', verticalalignment='center',
+                    transform=ax1.transAxes, fontsize=14)
+            ax1.set_title(f'PC{pc_idx + 1} - High Pole Topics', fontsize=16, fontweight='bold', color='darkred')
+            ax1.axis('off')
+        
+        # Process low pole topics
+        low_text = self._aggregate_topic_keywords(pc_topics['low'])
+        if low_text:
+            # Create blue colormap for low pole
+            colors_blue = ["#ccccff", "#9999ff", "#6666ff", "#3333ff", "#0000cc", "#000099"]
+            cmap_blue = LinearSegmentedColormap.from_list("blue_gradient", colors_blue)
+            
+            wc_low = WordCloud(
+                width=800,
+                height=400,
+                background_color='white',
+                colormap=cmap_blue,
+                max_words=max_words,
+                relative_scaling=0.5,
+                min_font_size=10
+            ).generate(low_text)
+            
+            ax2.imshow(wc_low, interpolation='bilinear')
+            ax2.set_title(f'PC{pc_idx + 1} - Low Pole Topics', fontsize=16, fontweight='bold', color='darkblue')
+            ax2.axis('off')
+        else:
+            ax2.text(0.5, 0.5, 'No significant low topics', 
+                    horizontalalignment='center', verticalalignment='center',
+                    transform=ax2.transAxes, fontsize=14)
+            ax2.set_title(f'PC{pc_idx + 1} - Low Pole Topics', fontsize=16, fontweight='bold', color='darkblue')
+            ax2.axis('off')
+        
+        plt.tight_layout()
+        
+        # Save if output directory provided
+        high_path = None
+        low_path = None
+        if output_dir:
+            os.makedirs(output_dir, exist_ok=True)
+            
+            # Save combined figure
+            combined_path = os.path.join(output_dir, f'pc{pc_idx + 1}_wordclouds.png')
+            fig.savefig(combined_path, dpi=300, bbox_inches='tight', facecolor='white')
+            
+            # Also save individual word clouds
+            if high_text:
+                fig_high, ax_high = plt.subplots(1, 1, figsize=figsize)
+                ax_high.imshow(wc_high, interpolation='bilinear')
+                ax_high.set_title(f'PC{pc_idx + 1} - High Pole Topics', fontsize=16, fontweight='bold', color='darkred')
+                ax_high.axis('off')
+                high_path = os.path.join(output_dir, f'pc{pc_idx + 1}_high_wordcloud.png')
+                fig_high.savefig(high_path, dpi=300, bbox_inches='tight', facecolor='white')
+                plt.close(fig_high)
+                
+            if low_text:
+                fig_low, ax_low = plt.subplots(1, 1, figsize=figsize)
+                ax_low.imshow(wc_low, interpolation='bilinear')
+                ax_low.set_title(f'PC{pc_idx + 1} - Low Pole Topics', fontsize=16, fontweight='bold', color='darkblue')
+                ax_low.axis('off')
+                low_path = os.path.join(output_dir, f'pc{pc_idx + 1}_low_wordcloud.png')
+                fig_low.savefig(low_path, dpi=300, bbox_inches='tight', facecolor='white')
+                plt.close(fig_low)
+        
+        if display:
+            plt.show()
+        else:
+            plt.close(fig)
+            
+        return fig, high_path, low_path
+    
+    def _aggregate_topic_keywords(self, topics: List[Dict]) -> str:
+        """
+        Aggregate keywords from multiple topics with frequency weighting.
+        
+        Parameters
+        ----------
+        topics : List[Dict]
+            List of topic dictionaries with 'keywords' field
+            
+        Returns
+        -------
+        str
+            Aggregated text with repeated keywords based on topic importance
+        """
+        if not topics:
+            return ""
+            
+        word_freq = Counter()
+        
+        for i, topic in enumerate(topics):
+            # Weight keywords by topic rank (higher rank = more frequent)
+            weight = len(topics) - i
+            keywords = topic['keywords'].split(' | ')
+            
+            for keyword in keywords:
+                # Clean keyword
+                keyword = keyword.strip()
+                if keyword and len(keyword) > 1:  # Skip single characters
+                    word_freq[keyword] += weight
+        
+        # Convert to text with repetitions
+        text_parts = []
+        for word, freq in word_freq.items():
+            text_parts.extend([word] * freq)
+            
+        return ' '.join(text_parts)
+    
+    def create_all_pc_wordclouds(self,
+                               pc_indices: Optional[List[int]] = None,
+                               k: int = 10,
+                               max_words: int = 100,
+                               figsize: Tuple[int, int] = (10, 5),
+                               output_dir: str = './wordclouds',
+                               display: bool = False) -> Dict[int, Tuple[str, str]]:
+        """
+        Create word clouds for all specified PCs.
+        
+        Parameters
+        ----------
+        pc_indices : List[int], optional
+            List of PC indices. If None, uses all available PCs
+        k : int
+            Number of topics to include from each pole
+        max_words : int
+            Maximum words to display in word cloud
+        figsize : Tuple[int, int]
+            Figure size for each subplot
+        output_dir : str
+            Directory to save output files
+        display : bool
+            Whether to display each plot
+            
+        Returns
+        -------
+        Dict[int, Tuple[str, str]]
+            Dictionary mapping PC index to (high_path, low_path)
+        """
+        if pc_indices is None:
+            pc_indices = list(range(self.topic_analyzer.pca_features.shape[1]))
+            
+        os.makedirs(output_dir, exist_ok=True)
+        output_paths = {}
+        
+        print(f"Generating word clouds for {len(pc_indices)} PCs...")
+        
+        for i, pc_idx in enumerate(pc_indices):
+            print(f"  Processing PC{pc_idx + 1} ({i + 1}/{len(pc_indices)})...")
+            
+            try:
+                _, high_path, low_path = self.create_pc_wordclouds(
+                    pc_idx=pc_idx,
+                    k=k,
+                    max_words=max_words,
+                    figsize=figsize,
+                    output_dir=output_dir,
+                    display=display
+                )
+                output_paths[pc_idx] = (high_path, low_path)
+                
+            except Exception as e:
+                print(f"    Warning: Failed to create word cloud for PC{pc_idx + 1}: {e}")
+                
+        print(f"\nGenerated word clouds saved to: {output_dir}")
+        return output_paths
+    
+    def create_top_pcs_wordcloud_grid(self,
+                                    pc_indices: List[int],
+                                    k: int = 10,
+                                    max_words: int = 50,
+                                    output_file: Optional[str] = None,
+                                    display: bool = True) -> plt.Figure:
+        """
+        Create a grid visualization of word clouds for top PCs.
+        
+        Parameters
+        ----------
+        pc_indices : List[int]
+            List of PC indices to visualize (max 9 for 3x3 grid)
+        k : int
+            Number of topics to include from each pole
+        max_words : int
+            Maximum words per word cloud
+        output_file : str, optional
+            Path to save the grid visualization
+        display : bool
+            Whether to display the plot
+            
+        Returns
+        -------
+        plt.Figure
+            Figure object
+        """
+        try:
+            from wordcloud import WordCloud
+        except ImportError:
+            raise ImportError("wordcloud package not installed. Install with: pip install wordcloud")
+            
+        # Limit to 9 PCs for 3x3 grid
+        pc_indices = pc_indices[:9]
+        n_pcs = len(pc_indices)
+        
+        # Calculate grid dimensions
+        n_cols = min(3, n_pcs)
+        n_rows = (n_pcs + n_cols - 1) // n_cols
+        
+        # Create figure
+        fig = plt.figure(figsize=(6 * n_cols, 4 * n_rows))
+        
+        # Create colormaps
+        colors_red = ["#ffcccc", "#ff9999", "#ff6666", "#ff3333", "#cc0000", "#990000"]
+        cmap_red = LinearSegmentedColormap.from_list("red_gradient", colors_red)
+        
+        colors_blue = ["#ccccff", "#9999ff", "#6666ff", "#3333ff", "#0000cc", "#000099"]
+        cmap_blue = LinearSegmentedColormap.from_list("blue_gradient", colors_blue)
+        
+        for i, pc_idx in enumerate(pc_indices):
+            # Get topics
+            pc_topics = self.topic_analyzer.get_pc_high_low_topics(
+                pc_idx=pc_idx,
+                n_high=k,
+                n_low=k,
+                p_threshold=0.05
+            )
+            
+            # High pole subplot
+            ax_high = plt.subplot(n_rows, n_cols * 2, i * 2 + 1)
+            high_text = self._aggregate_topic_keywords(pc_topics['high'])
+            
+            if high_text:
+                wc_high = WordCloud(
+                    width=400,
+                    height=200,
+                    background_color='white',
+                    colormap=cmap_red,
+                    max_words=max_words,
+                    relative_scaling=0.5,
+                    min_font_size=8
+                ).generate(high_text)
+                ax_high.imshow(wc_high, interpolation='bilinear')
+            else:
+                ax_high.text(0.5, 0.5, 'No topics', ha='center', va='center', transform=ax_high.transAxes)
+                
+            ax_high.set_title(f'PC{pc_idx + 1} High', fontsize=12, color='darkred')
+            ax_high.axis('off')
+            
+            # Low pole subplot
+            ax_low = plt.subplot(n_rows, n_cols * 2, i * 2 + 2)
+            low_text = self._aggregate_topic_keywords(pc_topics['low'])
+            
+            if low_text:
+                wc_low = WordCloud(
+                    width=400,
+                    height=200,
+                    background_color='white',
+                    colormap=cmap_blue,
+                    max_words=max_words,
+                    relative_scaling=0.5,
+                    min_font_size=8
+                ).generate(low_text)
+                ax_low.imshow(wc_low, interpolation='bilinear')
+            else:
+                ax_low.text(0.5, 0.5, 'No topics', ha='center', va='center', transform=ax_low.transAxes)
+                
+            ax_low.set_title(f'PC{pc_idx + 1} Low', fontsize=12, color='darkblue')
+            ax_low.axis('off')
+        
+        plt.suptitle('Principal Component Word Clouds - High (Red) vs Low (Blue) Poles', 
+                     fontsize=16, fontweight='bold')
+        plt.tight_layout()
+        
+        if output_file:
+            fig.savefig(output_file, dpi=300, bbox_inches='tight', facecolor='white')
+            print(f"Grid visualization saved to: {output_file}")
+            
+        if display:
+            plt.show()
+        else:
+            plt.close(fig)
+            
+        return fig

--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,7 @@ setup(
         "sentence-transformers>=2.0.0",
         "umap-learn>=0.5.0",
         "hdbscan>=0.8.27",
+        "wordcloud>=1.8.0",
     ],
     extras_require={
         "dev": [


### PR DESCRIPTION
## Summary
- Added word cloud visualization feature for PC poles
- Implemented PCWordCloudGenerator class with customizable parameters
- Integrated into main HAAM class with three new methods

## Features
- **Individual PC word clouds**: Generate word clouds for high (red) and low (blue) poles of any PC
- **Batch generation**: Process multiple PCs at once
- **Grid visualization**: Create compact grids showing multiple PCs
- **Customizable parameters**: Control number of topics (k), max words, and figure sizes

## Changes
- Added `haam/haam_wordcloud.py` with main implementation
- Updated `haam/haam_init.py` to integrate word cloud methods
- Added `wordcloud>=1.8.0` to dependencies in `setup.py`
- Created comprehensive documentation in `docs/wordcloud_feature.md`
- Added examples in `examples/wordcloud_example.py`
- Included Colab-ready script `generate_wordclouds_nvembed.py`

## Usage
```python
# Generate word clouds for a specific PC
fig, high_path, low_path = haam.create_pc_wordclouds(pc_idx=0, k=10)

# Batch generate for multiple PCs
output_paths = haam.create_all_pc_wordclouds(pc_indices=[0, 3, 7])

# Create grid visualization
fig = haam.create_top_pcs_wordcloud_grid()
```

## Test plan
- [x] Test single PC word cloud generation
- [x] Test batch generation
- [x] Test grid visualization
- [x] Verify color schemes (red for high, blue for low)
- [x] Test with missing topics handling

🤖 Generated with [Claude Code](https://claude.ai/code)